### PR TITLE
changes-DB-create-table-01

### DIFF
--- a/DB/create_table.sql
+++ b/DB/create_table.sql
@@ -100,7 +100,7 @@ CREATE TABLE IF NOT EXISTS `new_db_collection`.`files` (
   `file_checksum` VARCHAR(255) NOT NULL,
   `file_state` VARCHAR(45) NOT NULL,
   PRIMARY KEY (`vault_file_id`),
-  UNIQUE KEY `file_id_UNIQUE` (`vault_file_id`),
+  UNIQUE KEY `file_id_UNIQUE` (`vault_file_id`)
   -- KEY `fk_files_library1_idx` (`library_id`),
   -- KEY `fk_file_user_idx` (`user_id`),
   -- CONSTRAINT `fk_files_libraries`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,5 +34,11 @@ services:
       - '33061'
     networks:
       - todo-app
+    # Grant the container the CAP_SYS_NICE capability,
+    # which allows the container to raise process nice values,
+    # set real-time scheduling policies, set CPU affinity,
+    # and other operations.
+    cap_add:
+      - SYS_NICE
 networks:
   todo-app:


### PR DESCRIPTION
Fixes:
1. Bug in DB definition. it would error if left as is.
2. The docker container would not play well with the OS at least in MacOS. Need Grant the container the CAP_SYS_NICE capability, which allows the container to raise process nice values, set real-time scheduling policies, set CPU affinity, and other operations.